### PR TITLE
Added a --mazey option to the ep.py script

### DIFF
--- a/ep.py
+++ b/ep.py
@@ -6,7 +6,7 @@
 from escpos.printer import Usb
 from datetime import datetime
 
-import random, string, os, qrcode
+import random, string, os, qrcode, argparse
 
 # Use the system random number generator (which is os.urandom() which
 # will be /dev/urandom).
@@ -40,6 +40,12 @@ magic8 = ["It is certain", "It is decidedly so", "Without a doubt", "Yes, defini
           "Don't count on it", "My reply is no", "My sources say no", "Outlook not so good",
           "Very doubtful"]
 
+# define and parse a set of command line options
+parser = argparse.ArgumentParser()
+parser.add_argument("--mazey", type=bool, action="store_true", default=False,
+                    help="Print a mazey receipt, with only a maze and no other random data")
+args = parser.parse_args()
+
 qrl = ["Cloudflare"]
 p = get_printer()
 
@@ -49,39 +55,41 @@ text(p, "FREE RANDOMNESS")
 text(p, "FROM LAVA LAMPS")
 text(p, "& OTHER SOURCES")
 
-p.set("center")
-text(p, "\nRANDOM NUMBER < 1,000,000")
-text(p, str(rnd.randint(0, 999999)))
+if not args.mazey:
+    p.set("center")
+    text(p, "\nRANDOM NUMBER < 1,000,000")
+    text(p, str(rnd.randint(0, 999999)))
 
-# The diceware output requires the diceware program (pip install
-# diceware) That program uses random.SystemRandom by default
-text(p, "\nSIX WORD DICEWARE PASSWORD")
-dice = os.popen("diceware -d' '").read()
-qrl.append(dice)
-p.block_text(dice, 32)
-text(p, "")
+    # The diceware output requires the diceware program (pip install
+    # diceware) That program uses random.SystemRandom by default
+    text(p, "\nSIX WORD DICEWARE PASSWORD")
+    dice = os.popen("diceware -d' '").read()
+    qrl.append(dice)
+    p.block_text(dice, 32)
+    text(p, "")
 
-text(p, "\n128-BIT ENTROPY PASSWORDS")
-text(p, rand_string("0123456789ABCDEF", 32))
-text(p, rand_string(string.letters+string.digits, 22))
-text(p, rand_string(string.letters+string.digits+string.punctuation, 20))
+    text(p, "\n128-BIT ENTROPY PASSWORDS")
+    text(p, rand_string("0123456789ABCDEF", 32))
+    text(p, rand_string(string.letters+string.digits, 22))
+    text(p, rand_string(string.letters+string.digits+string.punctuation, 20))
 
-text(p, "\nMAGIC 8 BALL SAYS")
-text(p, rnd.choice(magic8))
+    text(p, "\nMAGIC 8 BALL SAYS")
+    text(p, rnd.choice(magic8))
 
-text(p, "\nSCAN ME")
-qr = qrcode.QRCode(version=None, box_size=4, border=1, error_correction=qrcode.constants.ERROR_CORRECT_L)
-qrl.append("cloudflare.com")
-qr.add_data("\n".join(qrl))
-qr.make(fit=True)
-img = qr.make_image()
-image(p, img._img.convert("RGB"))
+    text(p, "\nSCAN ME")
+    qr = qrcode.QRCode(version=None, box_size=4, border=1, error_correction=qrcode.constants.ERROR_CORRECT_L)
+    qrl.append("cloudflare.com")
+    qr.add_data("\n".join(qrl))
+    qr.make(fit=True)
+    img = qr.make_image()
+    image(p, img._img.convert("RGB"))
 
 text(p, "\nRANDOM PUZZLES")
 os.system("python mazes.py --prims -s 30 30")
 image(p, "maze.png")
-os.system("python sudoku.py")
-image(p, "sudoku.png")
+if not args.mazey:
+    os.system("python sudoku.py")
+    image(p, "sudoku.png")
 
 dt = datetime.utcnow()
 text(p, "\n" + dt.isoformat("Z"))


### PR DESCRIPTION
Since we all like being environmentally friendly, I think it's important that we have an option that only prints a random maze and no other data.

For one that like doing mazes, it's a lot of paper to waste to print all the data every time one makes a cup of tea.

**Note that this is untested as I do not have an rPi and receipt printer of my own.**