### PR TITLE
Fix F821 undefined name 'file' in Python 3

### DIFF
--- a/sudoku.py
+++ b/sudoku.py
@@ -31,6 +31,11 @@ xcoord  = [ 15, 55,  95,  139, 179, 219,  263, 303, 343 ]
 ycoord  = [ 56, 96, 136,  180, 220, 260,  304, 344, 384 ]
 numbers = []
 
+try:
+  file         # Python 2
+except NameError:
+  file = open  # Python 3
+
 def main():
   # Crop number bitmaps out of source image
   for i in range(9):


### PR DESCRIPTION
flake8 testing of https://github.com/cloudflare/receipt-printer on Python 3.6.2.

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./sudoku.py:207:7: F821 undefined name 'file'
  f = file(filename, 'r')
      ^
```