### PR TITLE
Replace deprecated datetime.utcnow

### DIFF
--- a/ep.py
+++ b/ep.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2017 Cloudflare, Inc.
 
 from escpos.printer import Usb
-from datetime import datetime
+from datetime import datetime, timezone
 
 import random, string, os, qrcode
 
@@ -83,7 +83,7 @@ image(p, "maze.png")
 os.system("python sudoku.py")
 image(p, "sudoku.png")
 
-dt = datetime.utcnow()
+dt = datetime.now(timezone.utc)
 text(p, "\n" + dt.isoformat("Z"))
 text(p, "cloudflare.com")
 

--- a/ep.py
+++ b/ep.py
@@ -84,7 +84,7 @@ os.system("python sudoku.py")
 image(p, "sudoku.png")
 
 dt = datetime.now(timezone.utc)
-text(p, "\n" + dt.isoformat("Z"))
+text(p, "\n" + dt.replace(tzinfo=None).isoformat("Z"))
 text(p, "cloudflare.com")
 
 p.cut()


### PR DESCRIPTION
utcnow method is deprecated since version 3.12. Replacing with datetime.now with UTC.

https://docs.python.org/3/library/datetime.html#:~:text=timezone.utc).-,Deprecated,-since%20version%203.12